### PR TITLE
Add scrollbar gutter to prevent layout shift on loading

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,5 +1,15 @@
 @import "vue-select/src/scss/vue-select.scss";
 
+html {
+  @apply bg-blue-50;
+  scrollbar-gutter: stable;
+
+  // @apply dark:bg-gray-800 doesn't seem to work directly on the html element
+  &.dark {
+    @apply bg-gray-800;
+  }
+}
+
 .container {
   @apply max-w-screen-xl;
   @apply m-auto;


### PR DESCRIPTION
There's a bug with the dolphin fella while the page loads which causes the scrollbar to flicker (and shift the whole page layout) on Chrome and Firefox:

https://user-images.githubusercontent.com/11708035/216335668-f6718e47-eaf6-42c7-aab8-35212069c24d.mp4

Note: the loading time has been greatly exaggerated on the video for demonstration purposes.

To mitigate it, I added `scrollbar-gutter: stable;` to the HTML element, which reserves a padding equivalent to the size of the browser scrollbar while it isn't present. This makes the layout not shift when the scrollbar appears or disappears. I also added a background color so that the gutter doesn't appear white and matches the page's bg color:

https://user-images.githubusercontent.com/11708035/216337315-e108096b-0d27-441c-9320-8280dd5a4efc.mp4

This doesn't fix the underlying dolphin bug. The scrollbar still appears and disappears. But this solution would be needed anyway, as if the bug was properly fixed, the page would still transition from no scrollbar -> scrollbar after loading, causing a layout shift.

`scrollbar-gutter` isn't supported on Safari, but I think that's OK, because by default macOS doesn't show scrollbars automatically unless you plug in a mouse. The workaround for Safari would be to scan the user agent and add `overflow-y: scroll` to `html` on Safari only.